### PR TITLE
Support manual background images

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,12 @@ Lightweight customizable placeholders for third party content of your website (e
 
 All widgets can be changed via data attributes:
 
-| Attribute     | Description                   | Example                                        |
-|---------------| ----------------------------- | ---------------------------------------------- |
-| `data-uc-src` | `src` of the original element | `data-uc-src="https://www.youtube.com/embed/xxx"` |
-| `data-text`   | Text for the placeholder      | `data-text="We need your consent"`             |
-| `data-accept` | Label for the accept button   | `data-accept="ok"`             |
+| Attribute                  | Description                     | Example                                                                       |
+|----------------------------|---------------------------------|-------------------------------------------------------------------------------|
+| `data-uc-src`              | `src` of the original element   | `data-uc-src="https://www.youtube.com/embed/xxx"`                             |
+| `data-text`                | Text for the placeholder        | `data-text="We need your consent"`                                            |
+| `data-accept`              | Label for the accept button     | `data-accept="ok"`                                                            |
+| `data-uc-background-image` | URL for custom background-image | `data-uc-background-image="https://picsum.photos/id/12/1920/1080.jpg"` |
 
 ##  Styling
 

--- a/src/widgets/Base.js
+++ b/src/widgets/Base.js
@@ -124,7 +124,8 @@ class Base {
    * @returns {string}
    */
   getBackground () {
-    return 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==';
+    const backgroundImage = this.el.getAttribute('data-uc-background-image');
+    return backgroundImage ?? 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==';
   }
 
   /**

--- a/src/widgets/Youtube.js
+++ b/src/widgets/Youtube.js
@@ -12,7 +12,8 @@ class Youtube extends Iframe {
    */
   getBackground () {
     const src = this.el.getAttribute('data-uc-src');
-    if (!src) {
+    const hasBackgroundImageSet = this.el.hasAttribute('data-uc-background-image');
+    if (!src || hasBackgroundImageSet) {
       return super.getBackground();
     }
     try {


### PR DESCRIPTION
This pull request adds the option to manually choose a background-image for an iFrame. 
This can be done, by using the `data-uc-background-image` attribute on the iframe. 

If no background-image is provided, the current default will be displayed.

`data-uc-background-image="https://picsum.photos/id/12/1920/1080.jpg"`