### PR TITLE
[DRAFT] Support using the consent in combination with a lightbox

### DIFF
--- a/src/widgets/Base.js
+++ b/src/widgets/Base.js
@@ -163,9 +163,14 @@ class Base {
     }
     this.el.replaceWith(container);
 
+    // save the activation method in the global scope, so it can be called from the button below,
+    // even after a clone of the node
+    const activationMethodName = `ucWidgetAcceptMethod${Math.floor(Math.random() * 1000000000)}`;
+    window[activationMethodName] = this.activate.bind(this, false);
+
     container
       .getElementsByClassName('uc-widget-accept')[0]
-      .addEventListener('click', this.activate.bind(this, true));
+      .setAttribute('onclick', `window['${activationMethodName}']()`);
 
     this.container = container;
 


### PR DESCRIPTION
When using the consent-box inside a lightbox, the consent-box node gets cloned, when the lightbox is opened. 
This causes the "activate" button to lose it's event listener.

The issue can be solved by using the `onclick` event on the button and saving the activation method inside the global window object. 

This pull request adds this functionality.

The generated markup for the button will look like this: 

```html
<button class="uc-widget-accept" onclick="window['ucWidgetAcceptMethod293945255']()">Accept</button>
```