### PR TITLE
feat: support Usercentrics v3 browser API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 Usercentrics Widgets 
 =====================
 
-Lightweight customizable placeholders for third party content of your website (e.g. Youtube Videos) compatible with the 
-[Usercentrics CMP](https://usercentrics.com).
+Lightweight customizable placeholders for third party content of your website (e.g. Youtube Videos) compatible with the
+[Usercentrics CMP](https://usercentrics.com). The library supports both the classic `UC_UI` interface and the
+Usercentrics v3 Browser API.
 
 * Unlike the [Usercentrics Smart Data Protector](https://docs.usercentrics.com/#/smart-data-protector), this library 
   **does not block** third party content automatically. You have to change your website according the documentation 

--- a/src/lib/WidgetStore.js
+++ b/src/lib/WidgetStore.js
@@ -78,7 +78,7 @@ class WidgetStore {
       cmp.waitForCmpConsent(ucId, () => this.activate(ucId));
     }
 
-    // react on changes of the CMP based UI events
+    // react on changes of the CMP based UI events (v2)
     window.addEventListener('UC_UI_VIEW_CHANGED', (e) => {
       if (e.detail && (e.detail.previousView === 'NONE' || e.detail.previousView === 'PRIVACY_BUTTON')) {
         return;
@@ -87,6 +87,18 @@ class WidgetStore {
         cmp.waitForCmpConsent(ucId, () => this.activate(ucId));
       }
     });
+
+    // react on consent changes for v3 API
+    if (window.Usercentrics) {
+      const add = window.Usercentrics.addEventListener || window.Usercentrics.on;
+      if (add) {
+        add.call(window.Usercentrics, 'consentChanged', () => {
+          for (const ucId of Object.keys(this.store)) {
+            cmp.waitForCmpConsent(ucId, () => this.activate(ucId));
+          }
+        });
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- add compatibility with Usercentrics v3 Browser API alongside legacy UC_UI
- listen for v3 consent changes to activate widgets
- document v3 support in README

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68acb9a5100c8333a35322a8146a91a8