### PR TITLE
Fix undefined variable extMatch in isSafeScriptUrl

### DIFF
--- a/src/config/ucw.config.example.js
+++ b/src/config/ucw.config.example.js
@@ -9,7 +9,7 @@ window.UCW_WIDGET_CONFIG = {
     de: {
       textHtml: '<p>Wir verwenden Dienste von Drittanbietern, um Ihnen Inhalte zur Verfügung zu stellen, beispielsweise Videos, Karten von Google, Formulare. Diese und andere Dienste nutzen Cookies.<br/>Damit wir Ihnen diesen Inhalt anzeigen können, benötigen wir Ihr Einverständnis. Dieses erklären Sie durch Klicken des Buttons “Cookies dauerhaft zulassen”.</p>',
       acceptLabel: 'Cookies dauerhaft zulassen',
-      acceptLabelClass: 'btn btn-primary',
+      acceptLabelClass: 'btn btn-primary'
       // Alternative to textHtml if you prefer the service name concatenation:
       // textServicePrefix: 'Wir nutzen den Service ',
       // textSuffixHtml: ' um Inhalte einzubetten. Dieser Service kann Daten zu Ihren Aktivitäten sammeln. Stimmen Sie der Nutzung des Service zu, um diese Inhalte anzuzeigen.'
@@ -17,7 +17,7 @@ window.UCW_WIDGET_CONFIG = {
     en: {
       textHtml: '<p>We use third-party services to provide you with content, such as videos, Google maps, and forms. These and other services use cookies.<br/>To display this content, we need your consent. You can give this by clicking the “Allow cookies permanently” button.</p>',
       acceptLabel: 'Allow cookies permanently',
-      acceptLabelClass: 'btn btn-primary',
+      acceptLabelClass: 'btn btn-primary'
       // Or use service name concatenation for EN:
       // textServicePrefix: 'We use the service ',
       // textSuffixHtml: ' to embed content. This service may collect data about your activities. Agree to use the Service to view this content.'

--- a/src/main.js
+++ b/src/main.js
@@ -36,7 +36,7 @@ async function loadConfigIfNeeded () {
  * Checks whether a script URL is safe to load.
  * Allows only same-origin relative or absolute URLs, and blocks javascript:, data:, etc.
  */
-function isSafeScriptUrl(url) {
+function isSafeScriptUrl (url) {
   try {
     // Trim leading/trailing whitespace, including Unicode whitespace
     url = url.trim();
@@ -45,6 +45,7 @@ function isSafeScriptUrl(url) {
     if (prohibited.test(url)) return false;
     // Try parsing the URL to allow only same-origin or relative URLs.
     const parsed = new URL(url, window.location.origin);
+    const extMatch = parsed.pathname.match(/\.([a-z0-9]+)$/i);
     if (parsed.origin !== window.location.origin) return false;
     // Additional restrictions can be added here, e.g. whitelist paths, etc.
     // Allow only .js files (optional safety, case-insensitive, strict).


### PR DESCRIPTION
Define extMatch from the parsed pathname to validate script file extension (.js/.mjs) in isSafeScriptUrl.

Additional adjustments:
- Apply semistandard lint fix in example config (remove trailing comma)

Validation:
- Ran 
> @netresearch/usercentrics-widgets@2.0.0 lint:fix
> ./node_modules/.bin/semistandard --fix ./src/** inside container (Node 22) — no remaining lint errors

Impact:
- Safer script URL handling; no user-facing API changes