### PR TITLE
Fix activation of multiple widgets on the same page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@netresearch/usercentrics-widgets",
-  "version": "2.0.4",
+  "version": "2.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@netresearch/usercentrics-widgets",
-      "version": "2.0.4",
+      "version": "2.0.7",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-terser": "^0.4.4"

--- a/src/lib/WidgetStore.js
+++ b/src/lib/WidgetStore.js
@@ -97,8 +97,20 @@ class WidgetStore {
     const widgets = this.store[ucId];
 
     if (widgets && widgets.length > 0) {
-      for (let i = 0; i < widgets.length; i++) {
-        widgets[i] && widgets[i].activate(false);
+      // Create a copy of the widgets array to avoid mutation issues during iteration
+      // When widgets[i].activate() is called, it internally calls unregister() which
+      // modifies the original array. Without copying, some widgets would be skipped.
+      const widgetsCopy = [...widgets];
+      
+      for (let i = 0; i < widgetsCopy.length; i++) {
+        if (widgetsCopy[i]) {
+          try {
+            widgetsCopy[i].activate(false);
+          } catch (e) {
+            // Log error but continue to activate other widgets
+            console.error('[Usercentrics Widgets] Failed to activate widget:', e);
+          }
+        }
       }
 
       this.activatedServices.add(ucId);

--- a/src/lib/WidgetStore.js
+++ b/src/lib/WidgetStore.js
@@ -101,7 +101,7 @@ class WidgetStore {
       // When widgets[i].activate() is called, it internally calls unregister() which
       // modifies the original array. Without copying, some widgets would be skipped.
       const widgetsCopy = [...widgets];
-      
+
       for (let i = 0; i < widgetsCopy.length; i++) {
         if (widgetsCopy[i]) {
           try {


### PR DESCRIPTION
Previously, when multiple widgets (e.g., YouTube videos) were present on a page, only the last widget would be properly activated when consent was granted. This was caused by the widgets array being modified during iteration in the activate() method.

The fix creates a copy of the widgets array before iteration to prevent skipping widgets when the original array is modified by unregister() calls during activation. Additionally, error handling was added to ensure that if one widget fails to activate, others can still proceed.